### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/lite/res/layout-hdpi/password_dialog.xml
+++ b/app/src/lite/res/layout-hdpi/password_dialog.xml
@@ -36,6 +36,7 @@
                     android:layout_margin="2dp"
                     android:hint="@string/password"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:maxLines="1"
                     android:visibility="gone"/>
                 <ImageButton
@@ -56,6 +57,7 @@
                     android:layout_marginTop="1dp"
                     android:hint="@string/repeat_password"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:maxLines="1"
                     android:visibility="gone" />
         </LinearLayout>

--- a/app/src/lite/res/layout-xhdpi/password_dialog.xml
+++ b/app/src/lite/res/layout-xhdpi/password_dialog.xml
@@ -44,6 +44,7 @@
                     android:layout_margin="2dp"
                     android:hint="@string/password"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:maxLines="1"
                     android:visibility="gone"/>
                 <ImageButton
@@ -64,6 +65,7 @@
                     android:layout_marginTop="1dp"
                     android:hint="@string/repeat_password"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:maxLines="1"
                     android:visibility="gone" />
         </LinearLayout>


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.